### PR TITLE
Raise error if Torch Softplus uses a custom beta

### DIFF
--- a/ext/MathOptAIPythonCallExt.jl
+++ b/ext/MathOptAIPythonCallExt.jl
@@ -121,6 +121,9 @@ function _predictor(nn, layer, config)
     elseif Bool(PythonCall.pybuiltins.isinstance(layer, nn.Sigmoid))
         return get(config, :Sigmoid, MathOptAI.Sigmoid())
     elseif Bool(PythonCall.pybuiltins.isinstance(layer, nn.Softplus))
+        if PythonCall.pyconvert(Float64, layer.beta) != 1.0
+            error("torch.nn.Softplus with beta != 1.0 is not supported")
+        end
         return get(config, :SoftPlus, MathOptAI.SoftPlus())
     elseif Bool(PythonCall.pybuiltins.isinstance(layer, nn.Tanh))
         return get(config, :Tanh, MathOptAI.Tanh())

--- a/test/test_PythonCall.jl
+++ b/test/test_PythonCall.jl
@@ -160,6 +160,32 @@ function test_model_SoftPlus()
     return
 end
 
+function test_model_SoftPlus_beta()
+    dir = mktempdir()
+    filename = joinpath(dir, "model_SoftPlus_beta.pt")
+    PythonCall.pyexec(
+        """
+        import torch
+
+        model = torch.nn.Sequential(
+            torch.nn.Linear(1, 16),
+            torch.nn.Softplus(beta=0.2),
+            torch.nn.Linear(16, 1),
+        )
+
+        torch.save(model, filename)
+        """,
+        @__MODULE__,
+        (; filename = filename),
+    )
+    model = Model(Ipopt.Optimizer)
+    set_silent(model)
+    @variable(model, x[1:1])
+    ml_model = MathOptAI.PytorchModel(filename)
+    @test_throws ErrorException y, formulation = MathOptAI.add_predictor(model, ml_model, x)
+    return
+end
+
 function test_model_Tanh()
     dir = mktempdir()
     filename = joinpath(dir, "model_Tanh.pt")


### PR DESCRIPTION
[Torch's softplus](https://pytorch.org/docs/stable/generated/torch.nn.Softplus.html#torch.nn.Softplus) is parameterized by a number, beta, that (I think) controls how closely the function approximates ReLU. I propose we raise an error if this parameter is set (to anything other than 1). The other option would be to support this in our SoftPlus implementation. From a quick scan, [Keras](https://www.tensorflow.org/api_docs/python/tf/keras/activations/softplus) and [Flux](https://fluxml.ai/Flux.jl/stable/reference/models/activation/#NNlib.softplus) don't have this parameter, so I think we probably don't need to support it either.