### PR TITLE
Add bound constraints to the Formulation object

### DIFF
--- a/src/predictors/Affine.jl
+++ b/src/predictors/Affine.jl
@@ -22,7 +22,7 @@ julia> using JuMP, MathOptAI
 
 julia> model = Model();
 
-julia> @variable(model, x[1:2]);
+julia> @variable(model, 0 <= x[i in 1:2] <= i);
 
 julia> f = MathOptAI.Affine([2.0 3.0], [4.0])
 Affine(A, b) [input: 2, output: 1]
@@ -37,7 +37,9 @@ julia> formulation
 Affine(A, b) [input: 2, output: 1]
 ├ variables [1]
 │ └ moai_Affine[1]
-└ constraints [1]
+└ constraints [3]
+  ├ moai_Affine[1] ≥ 4
+  ├ moai_Affine[1] ≤ 12
   └ 2 x[1] + 3 x[2] - moai_Affine[1] = -4
 
 julia> y, formulation =
@@ -75,6 +77,7 @@ function add_predictor(model::JuMP.AbstractModel, predictor::Affine, x::Vector)
     m = size(predictor.A, 1)
     y = JuMP.@variable(model, [1:m], base_name = "moai_Affine")
     bounds = _get_variable_bounds.(x)
+    cons = Any[]
     for i in 1:size(predictor.A, 1)
         y_lb, y_ub = predictor.b[i], predictor.b[i]
         for j in 1:size(predictor.A, 2)
@@ -83,9 +86,9 @@ function add_predictor(model::JuMP.AbstractModel, predictor::Affine, x::Vector)
             y_ub += a_ij * ifelse(a_ij >= 0, ub, lb)
             y_lb += a_ij * ifelse(a_ij >= 0, lb, ub)
         end
-        _set_bounds_if_finite(y[i], y_lb, y_ub)
+        _set_bounds_if_finite(cons, y[i], y_lb, y_ub)
     end
-    cons = JuMP.@constraint(model, predictor.A * x .+ predictor.b .== y)
+    append!(cons, JuMP.@constraint(model, predictor.A * x .+ predictor.b .== y))
     return y, Formulation(predictor, y, cons)
 end
 

--- a/src/predictors/Pipeline.jl
+++ b/src/predictors/Pipeline.jl
@@ -46,7 +46,9 @@ ReLUQuadratic()
 ├ variables [2]
 │ ├ moai_ReLU[1]
 │ └ moai_z[1]
-└ constraints [2]
+└ constraints [4]
+  ├ moai_ReLU[1] ≥ 0
+  ├ moai_z[1] ≥ 0
   ├ moai_Affine[1] - moai_ReLU[1] + moai_z[1] = 0
   └ moai_ReLU[1]*moai_z[1] = 0
 ```

--- a/src/predictors/Sigmoid.jl
+++ b/src/predictors/Sigmoid.jl
@@ -17,7 +17,7 @@ julia> using JuMP, MathOptAI
 
 julia> model = Model();
 
-julia> @variable(model, x[1:2]);
+julia> @variable(model, -1 <= x[i in 1:2] <= i);
 
 julia> f = MathOptAI.Sigmoid()
 Sigmoid()
@@ -35,10 +35,10 @@ Sigmoid()
 │ ├ moai_Sigmoid[1]
 │ └ moai_Sigmoid[2]
 └ constraints [6]
-  ├ moai_Sigmoid[1] ≥ 0
-  ├ moai_Sigmoid[1] ≤ 1
-  ├ moai_Sigmoid[2] ≥ 0
-  ├ moai_Sigmoid[2] ≤ 1
+  ├ moai_Sigmoid[1] ≥ 0.2689414213699951
+  ├ moai_Sigmoid[1] ≤ 0.7310585786300049
+  ├ moai_Sigmoid[2] ≥ 0.2689414213699951
+  ├ moai_Sigmoid[2] ≤ 0.8807970779778823
   ├ moai_Sigmoid[1] - (1.0 / (1.0 + exp(-x[1]))) = 0
   └ moai_Sigmoid[2] - (1.0 / (1.0 + exp(-x[2]))) = 0
 
@@ -58,10 +58,17 @@ ReducedSpace(Sigmoid())
 """
 struct Sigmoid <: AbstractPredictor end
 
+_eval(::Sigmoid, x::Real) = 1 / (1 + exp(-x))
+
 function add_predictor(model::JuMP.AbstractModel, predictor::Sigmoid, x::Vector)
     y = JuMP.@variable(model, [1:length(x)], base_name = "moai_Sigmoid")
     cons = Any[]
-    _set_bounds_if_finite.(Ref(cons), y, 0, 1)
+    for i in 1:length(x)
+        x_l, x_u = _get_variable_bounds(x[i])
+        y_l = x_l === nothing ? 0 : _eval(predictor, x_l)
+        y_u = x_u === nothing ? 1 : _eval(predictor, x_u)
+        _set_bounds_if_finite(cons, y[i], y_l, y_u)
+    end
     append!(cons, JuMP.@constraint(model, y .== 1 ./ (1 .+ exp.(-x))))
     return y, Formulation(predictor, y, cons)
 end

--- a/src/predictors/Sigmoid.jl
+++ b/src/predictors/Sigmoid.jl
@@ -36,8 +36,8 @@ Sigmoid()
 │ └ moai_Sigmoid[2]
 └ constraints [6]
   ├ moai_Sigmoid[1] ≥ 0
-  ├ moai_Sigmoid[2] ≥ 0
   ├ moai_Sigmoid[1] ≤ 1
+  ├ moai_Sigmoid[2] ≥ 0
   ├ moai_Sigmoid[2] ≤ 1
   ├ moai_Sigmoid[1] - (1.0 / (1.0 + exp(-x[1]))) = 0
   └ moai_Sigmoid[2] - (1.0 / (1.0 + exp(-x[2]))) = 0
@@ -60,10 +60,10 @@ struct Sigmoid <: AbstractPredictor end
 
 function add_predictor(model::JuMP.AbstractModel, predictor::Sigmoid, x::Vector)
     y = JuMP.@variable(model, [1:length(x)], base_name = "moai_Sigmoid")
-    _set_bounds_if_finite.(y, 0, 1)
-    cons = JuMP.@constraint(model, y .== 1 ./ (1 .+ exp.(-x)))
-    constraints = Any[JuMP.LowerBoundRef.(y); JuMP.UpperBoundRef.(y); cons]
-    return y, Formulation(predictor, y, constraints)
+    cons = Any[]
+    _set_bounds_if_finite.(Ref(cons), y, 0, 1)
+    append!(cons, JuMP.@constraint(model, y .== 1 ./ (1 .+ exp.(-x))))
+    return y, Formulation(predictor, y, cons)
 end
 
 function add_predictor(

--- a/src/predictors/SoftMax.jl
+++ b/src/predictors/SoftMax.jl
@@ -37,8 +37,8 @@ SoftMax()
 │ └ moai_SoftMax[2]
 └ constraints [8]
   ├ moai_SoftMax[1] ≥ 0
-  ├ moai_SoftMax[2] ≥ 0
   ├ moai_SoftMax[1] ≤ 1
+  ├ moai_SoftMax[2] ≥ 0
   ├ moai_SoftMax[2] ≤ 1
   ├ moai_SoftMax_denom ≥ 0
   ├ moai_SoftMax_denom - (0.0 + exp(x[2]) + exp(x[1])) = 0
@@ -66,19 +66,14 @@ struct SoftMax <: AbstractPredictor end
 
 function add_predictor(model::JuMP.AbstractModel, predictor::SoftMax, x::Vector)
     y = JuMP.@variable(model, [1:length(x)], base_name = "moai_SoftMax")
-    _set_bounds_if_finite.(y, 0, 1)
+    cons = Any[]
+    _set_bounds_if_finite.(Ref(cons), y, 0, 1)
     denom = JuMP.@variable(model, base_name = "moai_SoftMax_denom")
     JuMP.set_lower_bound(denom, 0)
-    d_con = JuMP.@constraint(model, denom == sum(exp.(x)))
-    cons = JuMP.@constraint(model, y .== exp.(x) ./ denom)
-    constraints = [
-        JuMP.LowerBoundRef.(y)
-        JuMP.UpperBoundRef.(y)
-        JuMP.LowerBoundRef(denom)
-        d_con
-        cons
-    ]
-    return y, Formulation(predictor, [denom; y], constraints)
+    push!(cons, JuMP.LowerBoundRef(denom))
+    push!(cons, JuMP.@constraint(model, denom == sum(exp.(x))))
+    append!(cons, JuMP.@constraint(model, y .== exp.(x) ./ denom))
+    return y, Formulation(predictor, [denom; y], cons)
 end
 
 function add_predictor(

--- a/src/predictors/SoftPlus.jl
+++ b/src/predictors/SoftPlus.jl
@@ -61,20 +61,15 @@ struct SoftPlus <: AbstractPredictor
     SoftPlus(; beta::Float64 = 1.0) = new(beta)
 end
 
-_softplus(f::SoftPlus, x::Real) = log(1 + exp(f.beta * x)) / f.beta
-
 function add_predictor(
     model::JuMP.AbstractModel,
     predictor::SoftPlus,
     x::Vector,
 )
-    beta = predictor.beta
+    β = predictor.beta
     y = JuMP.@variable(model, [1:length(x)], base_name = "moai_SoftPlus")
-    cons = _set_direct_bounds(x -> _softplus(beta), 0, nothing, x, y)
-    append!(
-        cons,
-        JuMP.@constraint(model, y .== log.(1 .+ exp.(beta .* x)) ./ beta),
-    )
+    cons = _set_direct_bounds(xi -> log(1 + exp(β * xi)) / β, 0, nothing, x, y)
+    append!(cons, JuMP.@constraint(model, y .== log.(1 .+ exp.(β .* x)) ./ β))
     return y, Formulation(predictor, y, cons)
 end
 

--- a/src/predictors/SoftPlus.jl
+++ b/src/predictors/SoftPlus.jl
@@ -65,10 +65,14 @@ function add_predictor(
     x::Vector,
 )
     y = JuMP.@variable(model, [1:length(x)], base_name = "moai_SoftPlus")
-    _set_bounds_if_finite.(y, 0, nothing)
+    cons = Any[]
+    _set_bounds_if_finite.(Ref(cons), y, 0, nothing)
     beta = predictor.beta
-    cons = JuMP.@constraint(model, y .== log.(1 .+ exp.(beta .* x)) ./ beta)
-    return y, Formulation(predictor, y, Any[JuMP.LowerBoundRef.(y); cons])
+    append!(
+        cons,
+        JuMP.@constraint(model, y .== log.(1 .+ exp.(beta .* x)) ./ beta),
+    )
+    return y, Formulation(predictor, y, cons)
 end
 
 function add_predictor(

--- a/src/predictors/SoftPlus.jl
+++ b/src/predictors/SoftPlus.jl
@@ -70,7 +70,7 @@ function add_predictor(
 )
     beta = predictor.beta
     y = JuMP.@variable(model, [1:length(x)], base_name = "moai_SoftPlus")
-    cons = _set_variable_bounds(x -> _softplus(beta), 0, nothing, x, y)
+    cons = _set_direct_bounds(x -> _softplus(beta), 0, nothing, x, y)
     append!(
         cons,
         JuMP.@constraint(model, y .== log.(1 .+ exp.(beta .* x)) ./ beta),

--- a/src/predictors/Tanh.jl
+++ b/src/predictors/Tanh.jl
@@ -17,7 +17,7 @@ julia> using JuMP, MathOptAI
 
 julia> model = Model();
 
-julia> @variable(model, x[1:2]);
+julia> @variable(model, -1 <= x[i in 1:2] <= i);
 
 julia> f = MathOptAI.Tanh()
 Tanh()
@@ -35,10 +35,10 @@ Tanh()
 │ ├ moai_Tanh[1]
 │ └ moai_Tanh[2]
 └ constraints [6]
-  ├ moai_Tanh[1] ≥ -1
-  ├ moai_Tanh[1] ≤ 1
-  ├ moai_Tanh[2] ≥ -1
-  ├ moai_Tanh[2] ≤ 1
+  ├ moai_Tanh[1] ≥ -0.7615941559557649
+  ├ moai_Tanh[1] ≤ 0.7615941559557649
+  ├ moai_Tanh[2] ≥ -0.7615941559557649
+  ├ moai_Tanh[2] ≤ 0.9640275800758169
   ├ moai_Tanh[1] - tanh(x[1]) = 0
   └ moai_Tanh[2] - tanh(x[2]) = 0
 
@@ -58,10 +58,17 @@ ReducedSpace(Tanh())
 """
 struct Tanh <: AbstractPredictor end
 
+_eval(::Tanh, x::Real) = tanh(x)
+
 function add_predictor(model::JuMP.AbstractModel, predictor::Tanh, x::Vector)
     y = JuMP.@variable(model, [1:length(x)], base_name = "moai_Tanh")
     cons = Any[]
-    _set_bounds_if_finite.(Ref(cons), y, -1, 1)
+    for i in 1:length(x)
+        x_l, x_u = _get_variable_bounds(x[i])
+        y_l = x_l === nothing ? -1 : _eval(predictor, x_l)
+        y_u = x_u === nothing ? 1 : _eval(predictor, x_u)
+        _set_bounds_if_finite(cons, y[i], y_l, y_u)
+    end
     append!(cons, JuMP.@constraint(model, y .== tanh.(x)))
     return y, Formulation(predictor, y, cons)
 end

--- a/src/predictors/Tanh.jl
+++ b/src/predictors/Tanh.jl
@@ -58,8 +58,6 @@ ReducedSpace(Tanh())
 """
 struct Tanh <: AbstractPredictor end
 
-_eval(::Tanh, x::Real) = tanh(x)
-
 function add_predictor(model::JuMP.AbstractModel, predictor::Tanh, x::Vector)
     y = JuMP.@variable(model, [1:length(x)], base_name = "moai_Tanh")
     cons = _set_variable_bounds(tanh, -1, 1, x, y)

--- a/src/predictors/Tanh.jl
+++ b/src/predictors/Tanh.jl
@@ -62,13 +62,7 @@ _eval(::Tanh, x::Real) = tanh(x)
 
 function add_predictor(model::JuMP.AbstractModel, predictor::Tanh, x::Vector)
     y = JuMP.@variable(model, [1:length(x)], base_name = "moai_Tanh")
-    cons = Any[]
-    for i in 1:length(x)
-        x_l, x_u = _get_variable_bounds(x[i])
-        y_l = x_l === nothing ? -1 : _eval(predictor, x_l)
-        y_u = x_u === nothing ? 1 : _eval(predictor, x_u)
-        _set_bounds_if_finite(cons, y[i], y_l, y_u)
-    end
+    cons = _set_variable_bounds(tanh, -1, 1, x, y)
     append!(cons, JuMP.@constraint(model, y .== tanh.(x)))
     return y, Formulation(predictor, y, cons)
 end

--- a/src/predictors/Tanh.jl
+++ b/src/predictors/Tanh.jl
@@ -36,8 +36,8 @@ Tanh()
 │ └ moai_Tanh[2]
 └ constraints [6]
   ├ moai_Tanh[1] ≥ -1
-  ├ moai_Tanh[2] ≥ -1
   ├ moai_Tanh[1] ≤ 1
+  ├ moai_Tanh[2] ≥ -1
   ├ moai_Tanh[2] ≤ 1
   ├ moai_Tanh[1] - tanh(x[1]) = 0
   └ moai_Tanh[2] - tanh(x[2]) = 0
@@ -60,10 +60,10 @@ struct Tanh <: AbstractPredictor end
 
 function add_predictor(model::JuMP.AbstractModel, predictor::Tanh, x::Vector)
     y = JuMP.@variable(model, [1:length(x)], base_name = "moai_Tanh")
-    _set_bounds_if_finite.(y, -1, 1)
-    cons = JuMP.@constraint(model, y .== tanh.(x))
-    constraints = Any[JuMP.LowerBoundRef.(y); JuMP.UpperBoundRef.(y); cons]
-    return y, Formulation(predictor, y, constraints)
+    cons = Any[]
+    _set_bounds_if_finite.(Ref(cons), y, -1, 1)
+    append!(cons, JuMP.@constraint(model, y .== tanh.(x)))
+    return y, Formulation(predictor, y, cons)
 end
 
 function add_predictor(

--- a/src/predictors/Tanh.jl
+++ b/src/predictors/Tanh.jl
@@ -60,7 +60,7 @@ struct Tanh <: AbstractPredictor end
 
 function add_predictor(model::JuMP.AbstractModel, predictor::Tanh, x::Vector)
     y = JuMP.@variable(model, [1:length(x)], base_name = "moai_Tanh")
-    cons = _set_variable_bounds(tanh, -1, 1, x, y)
+    cons = _set_direct_bounds(tanh, -1, 1, x, y)
     append!(cons, JuMP.@constraint(model, y .== tanh.(x)))
     return y, Formulation(predictor, y, cons)
 end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -22,15 +22,18 @@ function _get_variable_bounds(x::JuMP.GenericVariableRef{T}) where {T}
 end
 
 function _set_bounds_if_finite(
+    cons::Vector,
     x::JuMP.GenericVariableRef{T},
     l::Union{Nothing,Real},
     u::Union{Nothing,Real},
 ) where {T}
     if l !== nothing && l > typemin(T)
         JuMP.set_lower_bound(x, l)
+        push!(cons, JuMP.LowerBoundRef(x))
     end
     if u !== nothing && u < typemax(T)
         JuMP.set_upper_bound(x, u)
+        push!(cons, JuMP.UpperBoundRef(x))
     end
     return
 end
@@ -39,4 +42,4 @@ end
 _get_variable_bounds(::Any) = -Inf, Inf
 
 # Default fallback: skip setting variable bound
-_set_bounds_if_finite(::Any, ::Any, ::Any) = nothing
+_set_bounds_if_finite(::Vector, ::Any, ::Any, ::Any) = nothing

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -44,7 +44,6 @@ _get_variable_bounds(::Any) = -Inf, Inf
 # Default fallback: skip setting variable bound
 _set_bounds_if_finite(::Vector, ::Any, ::Any, ::Any) = nothing
 
-
 function _set_direct_bounds(f::F, l, u, x::Vector, y::Vector) where {F}
     cons = Any[]
     for (xi, yi) in zip(x, y)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -43,3 +43,15 @@ _get_variable_bounds(::Any) = -Inf, Inf
 
 # Default fallback: skip setting variable bound
 _set_bounds_if_finite(::Vector, ::Any, ::Any, ::Any) = nothing
+
+
+function _set_direct_bounds(f::F, l, u, x::Vector, y::Vector) where {F}
+    cons = Any[]
+    for (xi, yi) in zip(x, y)
+        x_l, x_u = _get_variable_bounds(xi)
+        y_l = x_l === nothing ? l : f(x_l)
+        y_u = x_u === nothing ? u : f(x_u)
+        _set_bounds_if_finite(cons, yi, y_l, y_u)
+    end
+    return cons
+end

--- a/test/test_predictors.jl
+++ b/test/test_predictors.jl
@@ -147,7 +147,7 @@ function test_ReLU_bounds()
             model = Model()
             @variable(model, lb <= x <= ub)
             y, _ = MathOptAI.add_predictor(model, f, [x])
-            @test lower_bound.(y) == [0.0]
+            @test lower_bound.(y) == [max(0.0, lb)]
             @test upper_bound.(y) == [max(0.0, ub)]
         end
     end
@@ -254,6 +254,22 @@ function test_Sigmoid()
     return
 end
 
+function test_Sigmoid_bounds()
+    f(x) = 1 / (1 + exp(-x))
+    values = [-Inf, -2, 0, 2, Inf]
+    for lb in values, ub in values
+        if lb == Inf || ub == -Inf || lb > ub
+            continue
+        end
+        model = Model()
+        @variable(model, lb <= x <= ub)
+        y, _ = MathOptAI.add_predictor(model, MathOptAI.Sigmoid(), [x])
+        @test lower_bound(y[1]) == f(lb)
+        @test upper_bound(y[1]) == f(ub)
+    end
+    return
+end
+
 function test_ReducedSpace_Sigmoid()
     model = Model(Ipopt.Optimizer)
     set_silent(model)
@@ -324,6 +340,26 @@ function test_SoftPlus()
     return
 end
 
+function test_SoftPlus_bounds()
+    f(x, beta) = log(1 + exp(beta * x)) / beta
+    values = [-Inf, -2, 0, 2, Inf]
+    for beta in [1.0, 1.5, 2.0], lb in values, ub in values
+        if lb == Inf || ub == -Inf || lb > ub
+            continue
+        end
+        model = Model()
+        @variable(model, lb <= x <= ub)
+        y, _ = MathOptAI.add_predictor(model, MathOptAI.SoftPlus(; beta), [x])
+        @test lower_bound(y[1]) == f(lb, beta)
+        if isfinite(ub)
+            @test upper_bound(y[1]) == f(ub, beta)
+        else
+            @test !has_upper_bound(y[1])
+        end
+    end
+    return
+end
+
 function test_ReducedSpace_SoftPlus()
     model = Model(Ipopt.Optimizer)
     set_silent(model)
@@ -356,6 +392,21 @@ function test_Tanh()
     optimize!(model)
     @assert is_solved_and_feasible(model)
     @test value.(y) ≈ tanh.(X)
+    return
+end
+
+function test_Tanh_bounds()
+    values = [-Inf, -2, 0, 2, Inf]
+    for lb in values, ub in values
+        if lb == Inf || ub == -Inf || lb > ub
+            continue
+        end
+        model = Model()
+        @variable(model, lb <= x <= ub)
+        y, _ = MathOptAI.add_predictor(model, MathOptAI.Tanh(), [x])
+        @test lower_bound.(y) == [tanh(lb)]
+        @test upper_bound.(y) == [tanh(ub)]
+    end
     return
 end
 

--- a/test/test_predictors.jl
+++ b/test/test_predictors.jl
@@ -408,7 +408,8 @@ function test_fallback_bound_methods()
     fake_variable = "x"
     l, u = MathOptAI._get_variable_bounds(fake_variable)
     @test (l, u) == (-Inf, Inf)
-    @test MathOptAI._set_bounds_if_finite(fake_variable, l, u) === nothing
+    cons = Any[]
+    @test MathOptAI._set_bounds_if_finite(cons, fake_variable, l, u) === nothing
     return
 end
 


### PR DESCRIPTION
This is nominally breaking, but I don't think anyone is relying on the specific order of the `.constraints` yet.

I should also work on tightening the bounds for the activation functions.