### PR TITLE
Fix binary decision tree by making the tolerance default to 1e-6

### DIFF
--- a/ext/MathOptAIDecisionTreeExt.jl
+++ b/ext/MathOptAIDecisionTreeExt.jl
@@ -68,7 +68,7 @@ function MathOptAI.build_predictor(
     };
     kwargs...,
 )
-    return _build_predictor(predictor; kwargs...,)
+    return _build_predictor(predictor; kwargs...)
 end
 
 function _build_predictor(p::DecisionTree.Root; kwargs...)

--- a/src/predictors/AffineCombination.jl
+++ b/src/predictors/AffineCombination.jl
@@ -72,9 +72,9 @@ BinaryDecisionTree{Float64,Int64} [leaves=3, depth=2]
 │ └ moai_BinaryDecisionTree_z[3]
 └ constraints [7]
   ├ moai_BinaryDecisionTree_z[1] + moai_BinaryDecisionTree_z[2] + moai_BinaryDecisionTree_z[3] = 1
-  ├ moai_BinaryDecisionTree_z[1] --> {x[1] ≤ 0}
+  ├ moai_BinaryDecisionTree_z[1] --> {x[1] ≤ -1.0e-6}
   ├ moai_BinaryDecisionTree_z[2] --> {x[1] ≥ 0}
-  ├ moai_BinaryDecisionTree_z[2] --> {x[1] ≤ 1}
+  ├ moai_BinaryDecisionTree_z[2] --> {x[1] ≤ 0.999999}
   ├ moai_BinaryDecisionTree_z[3] --> {x[1] ≥ 0}
   ├ moai_BinaryDecisionTree_z[3] --> {x[1] ≥ 1}
   └ moai_BinaryDecisionTree_z[1] - moai_BinaryDecisionTree_z[3] + moai_BinaryDecisionTree_value = 0
@@ -86,9 +86,9 @@ BinaryDecisionTree{Float64,Int64} [leaves=3, depth=2]
 │ └ moai_BinaryDecisionTree_z[3]
 └ constraints [7]
   ├ moai_BinaryDecisionTree_z[1] + moai_BinaryDecisionTree_z[2] + moai_BinaryDecisionTree_z[3] = 1
-  ├ moai_BinaryDecisionTree_z[1] --> {x[1] ≤ 0.9}
-  ├ moai_BinaryDecisionTree_z[1] --> {x[1] ≤ -0.1}
-  ├ moai_BinaryDecisionTree_z[2] --> {x[1] ≤ 0.9}
+  ├ moai_BinaryDecisionTree_z[1] --> {x[1] ≤ 0.899999}
+  ├ moai_BinaryDecisionTree_z[1] --> {x[1] ≤ -0.100001}
+  ├ moai_BinaryDecisionTree_z[2] --> {x[1] ≤ 0.899999}
   ├ moai_BinaryDecisionTree_z[2] --> {x[1] ≥ -0.1}
   ├ moai_BinaryDecisionTree_z[3] --> {x[1] ≥ 0.9}
   └ moai_BinaryDecisionTree_z[1] - moai_BinaryDecisionTree_z[3] + moai_BinaryDecisionTree_value = 0


### PR DESCRIPTION
Closes #195

Strict inequalities like `x < 0` are tricky to enforce in a MIP because of tolerances.

I've changed the default tolerance to `1e-6`, and fixed support for passing a different `; atol` at the `add_predictor` stage.