### PR TITLE
[breaking] remove ::Matrix method that maps over columns

### DIFF
--- a/ext/MathOptAIStatsModelsExt.jl
+++ b/ext/MathOptAIStatsModelsExt.jl
@@ -70,11 +70,13 @@ function MathOptAI.add_predictor(
     kwargs...,
 )
     resp = StatsModels.modelcols(StatsModels.MatrixTerm(predictor.mf.f.rhs), df)
-    x = Matrix(resp')
-    y, formulation =
-        MathOptAI.add_predictor(model, predictor.model, x; kwargs...)
-    @assert size(y, 1) == 1
-    return reshape(y, length(y)), formulation
+    p = MathOptAI.build_predictor(predictor.model)
+    ret = [
+        MathOptAI.add_predictor(model, p, collect(row); kwargs...) for
+        row in eachrow(resp)
+    ]
+    formulation = MathOptAI.PipelineFormulation(p, last.(ret))
+    return reduce(vcat, first.(ret)), formulation
 end
 
 end  # module MathOptAIStatsModelsExt

--- a/src/MathOptAI.jl
+++ b/src/MathOptAI.jl
@@ -191,55 +191,6 @@ function add_predictor(
 end
 
 """
-    add_predictor(model::JuMP.AbstractModel, predictor, x::Matrix)
-
-Return a `Matrix`, representing `y` such that `y[:, i] = predictor(x[:, i])` for
-each column `i`.
-
-## Example
-
-```jldoctest
-julia> using JuMP, MathOptAI
-
-julia> model = Model();
-
-julia> @variable(model, x[1:2, 1:3]);
-
-julia> f = MathOptAI.Affine([2.0, 3.0])
-Affine(A, b) [input: 2, output: 1]
-
-julia> y, formulation = MathOptAI.add_predictor(model, f, x);
-
-julia> y
-1×3 Matrix{VariableRef}:
- moai_Affine[1]  moai_Affine[1]  moai_Affine[1]
-
-julia> formulation
-Affine(A, b) [input: 2, output: 1]
-├ variables [1]
-│ └ moai_Affine[1]
-└ constraints [1]
-  └ 2 x[1,1] + 3 x[2,1] - moai_Affine[1] = 0
-Affine(A, b) [input: 2, output: 1]
-├ variables [1]
-│ └ moai_Affine[1]
-└ constraints [1]
-  └ 2 x[1,2] + 3 x[2,2] - moai_Affine[1] = 0
-Affine(A, b) [input: 2, output: 1]
-├ variables [1]
-│ └ moai_Affine[1]
-└ constraints [1]
-  └ 2 x[1,3] + 3 x[2,3] - moai_Affine[1] = 0
-```
-"""
-function add_predictor(model::JuMP.AbstractModel, predictor, x::Matrix)
-    inner_predictor = build_predictor(predictor)
-    ret = map(j -> add_predictor(model, inner_predictor, x[:, j]), 1:size(x, 2))
-    formulation = PipelineFormulation(inner_predictor, last.(ret))
-    return reduce(hcat, first.(ret)), formulation
-end
-
-"""
     build_predictor(extension; kwargs...)::AbstractPredictor
 
 A uniform interface to convert various extension types to an


### PR DESCRIPTION
Part of #109

I think I'm going to do a few things:

 * Remove this method (#223)
 * Add a new method that calls `vec` and then sets `input_size` (#224)
 * Release a breaking v1.0.0 version to go with the paper (#225)