### PR TITLE
Add ReLUEpigraph

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -136,6 +136,11 @@ ReLU
 ReLUBigM
 ```
 
+## `ReLUEpigraph`
+```@docs
+ReLUEpigraph
+```
+
 ## `ReLUQuadratic`
 ```@docs
 ReLUQuadratic

--- a/docs/src/manual/predictors.md
+++ b/docs/src/manual/predictors.md
@@ -32,6 +32,7 @@ The following predictors are supported. See their docstrings for details:
 | [`Quantile`](@ref)           | Local nonlinear       | Yes  |           |
 | [`ReLU`](@ref)               | Global nonlinear      | Yes  | Yes       |
 | [`ReLUBigM`](@ref)           | Mixed-integer linear  | Yes  |           |
+| [`ReLUEpigraph`](@ref)       | Linear                | Yes  |           |
 | [`ReLUQuadratic`](@ref)      | Non-convex quadratic  | Yes  |           |
 | [`ReLUSOS1`](@ref)           | Mixed-integer linear  | Yes  |           |
 | [`Scale`](@ref)              | Linear                | Yes  | Yes       |

--- a/src/MathOptAI.jl
+++ b/src/MathOptAI.jl
@@ -358,6 +358,7 @@ output_size(::AbstractPredictor, ::Any) = nothing
 
 for file in readdir(joinpath(@__DIR__, "predictors"); join = true)
     if endswith(file, ".jl")
+        @show file
         include(file)
     end
 end

--- a/src/MathOptAI.jl
+++ b/src/MathOptAI.jl
@@ -358,7 +358,6 @@ output_size(::AbstractPredictor, ::Any) = nothing
 
 for file in readdir(joinpath(@__DIR__, "predictors"); join = true)
     if endswith(file, ".jl")
-        @show file
         include(file)
     end
 end

--- a/src/MathOptAI.jl
+++ b/src/MathOptAI.jl
@@ -356,8 +356,8 @@ julia> output_size(MaxPool2d((3, 3); input_size = (6, 9, 1)), (6, 9, 1))
 """
 output_size(::AbstractPredictor, ::Any) = nothing
 
-for file in readdir(joinpath(@__DIR__, "predictors"); join = true)
-    if endswith(file, ".jl")
+let predictors = joinpath(@__DIR__, "predictors")
+    for file in filter(endswith(".jl"), readdir(predictors; join = true))
         include(file)
     end
 end

--- a/src/predictors/ReLUEpigraph.jl
+++ b/src/predictors/ReLUEpigraph.jl
@@ -1,0 +1,69 @@
+# Copyright (c) 2024: Triad National Security, LLC
+# Copyright (c) 2024: Oscar Dowson and contributors
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
+"""
+    ReLUEpigraph() <: AbstractPredictor
+
+An [`AbstractPredictor`](@ref) that represents the relationship:
+```math
+y = \\max\\{0, x\\}
+```
+by the reformulation:
+```math
+\\begin{aligned}
+y \\ge x \\\\
+y \\ge 0
+\\end{aligned}
+```
+
+## Example
+
+```jldoctest
+julia> using JuMP, MathOptAI
+
+julia> model = Model();
+
+julia> @variable(model, -1 <= x[i in 1:2] <= i);
+
+julia> f = MathOptAI.ReLUEpigraph()
+ReLUEpigraph()
+
+julia> y, formulation = MathOptAI.add_predictor(model, f, x);
+
+julia> y
+2-element Vector{VariableRef}:
+ moai_ReLUEpigraph[1]
+ moai_ReLUEpigraph[2]
+
+julia> formulation
+ReLUEpigraph()
+├ variables [1]
+│ └ VariableRef[moai_ReLUEpigraph[1], moai_ReLUEpigraph[2]]
+└ constraints [4]
+  ├ -x[1] + moai_ReLUEpigraph[1] ≥ 0
+  ├ moai_ReLUEpigraph[1] ≥ 0
+  ├ -x[2] + moai_ReLUEpigraph[2] ≥ 0
+  └ moai_ReLUEpigraph[2] ≥ 0
+```
+"""
+struct ReLUEpigraph <: AbstractPredictor end
+
+output_size(::ReLUEpigraph, input_size) = input_size
+
+function add_predictor(
+    model::JuMP.AbstractModel,
+    predictor::ReLUEpigraph,
+    x::Vector,
+)
+    y = add_variables(model, x, length(x), "moai_ReLUEpigraph")
+    cons = Any[]
+    for i in 1:length(x)
+        l, u = max.(0, get_variable_bounds(x[i]))
+        push!(cons, JuMP.@constraint(model, y[i] >= x[i]))
+        set_variable_bounds(cons, y[i], coalesce(l, 0), u; optional = false)
+    end
+    return y, Formulation(predictor, y, cons)
+end

--- a/src/predictors/ReLUEpigraph.jl
+++ b/src/predictors/ReLUEpigraph.jl
@@ -40,13 +40,16 @@ julia> y
 
 julia> formulation
 ReLUEpigraph()
-├ variables [1]
-│ └ VariableRef[moai_ReLUEpigraph[1], moai_ReLUEpigraph[2]]
-└ constraints [4]
+├ variables [2]
+│ ├ moai_ReLUEpigraph[1]
+│ └ moai_ReLUEpigraph[2]
+└ constraints [6]
   ├ -x[1] + moai_ReLUEpigraph[1] ≥ 0
   ├ moai_ReLUEpigraph[1] ≥ 0
+  ├ moai_ReLUEpigraph[1] ≤ 1
   ├ -x[2] + moai_ReLUEpigraph[2] ≥ 0
-  └ moai_ReLUEpigraph[2] ≥ 0
+  ├ moai_ReLUEpigraph[2] ≥ 0
+  └ moai_ReLUEpigraph[2] ≤ 2
 ```
 """
 struct ReLUEpigraph <: AbstractPredictor end

--- a/test/test_predictors.jl
+++ b/test/test_predictors.jl
@@ -232,6 +232,24 @@ function test_ReLU_BigM()
     return
 end
 
+function test_ReLU_Epigraph()
+    model = Model(Ipopt.Optimizer)
+    set_silent(model)
+    @variable(model, x[1:2])
+    f = MathOptAI.ReLUEpigraph()
+    @test MathOptAI.output_size(f, (10,)) == (10,)
+    y, formulation = MathOptAI.add_predictor(model, f, x)
+    @test length(y) == 2
+    @test num_variables(model) == 4
+    @test num_constraints(model, AffExpr, MOI.GreaterThan{Float64}) == 2
+    @objective(model, Min, sum(y))
+    fix.(x, [-1, 2])
+    optimize!(model)
+    @assert is_solved_and_feasible(model)
+    @test value.(y) ≈ [0.0, 2.0]
+    return
+end
+
 function test_ReLU_SOS1()
     model = Model(HiGHS.Optimizer)
     set_silent(model)


### PR DESCRIPTION
This will allow convex surrogates to be embedded as an LP

## The predictor

 - [x] Create a new file in `src/predictors`
 - [x] Add the default copyright header
 - [x] Make a new `<: AbstractPredictor`  type
 - [x] Add a docstring to the predictor
 - [x] Add the predictor to `docs/src/api.md`
 - [x] Add the predictor to `docs/src/manual/predictors.md`
 - [x] Implement `output_size`
 - [x] Implement `add_predictor(model, ::NewPredictor, x)`
 - [x] Optionally implement `add_predictor(model, ::ReducedSpace{NewPredictor}, x)`
 - [x] Add a test to `test/test_predictors.jl`

## Extensions

For each revelevant extension:

 - [x] Add support for the new predictor
 - [x] Add tests
 - [x] Mention the predictor in the docstring of the relevant `build_predictor`
 - [x] Mention the predictor in the relevant `docs/src/manual/<ext>.md`